### PR TITLE
added missing scapy dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
     description='UniFlex WIFI Module',
     long_description='UniFlex WIFI Module',
     keywords='wireless control',
-    install_requires=['pyric', 'pyshark']
+    install_requires=['pyric', 'pyshark', 'scapy>=2.4.0rc4']
 )


### PR DESCRIPTION
This is still development version of the original scapy, but brings in python3 and 2 support.

I don't think #1 is useful as scapy3k has different API, it was forked long time ago, didn't receive all bug fixes and is py3 only (not sure if we support py2?).